### PR TITLE
Fix bug making images with missing DateTime in metadata crash.

### DIFF
--- a/src/imgtrf/meta.py
+++ b/src/imgtrf/meta.py
@@ -65,9 +65,13 @@ def get_image_creation_time(path: Path) -> Optional[datetime]:
 
     time_format = r"%Y:%m:%d %H:%M:%S"
     time_string = metadata.get("DateTime")
-    creation_time = datetime.strptime(time_string, time_format)
-
-    return creation_time
+    if time_string:
+        creation_time = datetime.strptime(time_string, time_format)
+        return creation_time
+    
+    else:
+        log.debug(f"Could not find 'DateTime' in {path}")
+        return None
 
 
 @log_func(log)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from pathlib import Path
 
 
-def create_image(directory: Path, file_name: str, creation_date: datetime):
+def create_image(directory: Path, file_name: str, creation_date: datetime) -> Path:
     """Create dummy image with metadata
 
     Reference
@@ -27,6 +27,16 @@ def create_image(directory: Path, file_name: str, creation_date: datetime):
         exif.update({"Exif": {piexif.ExifIFD.DateTimeOriginal: time_string}})
         exif.update({"Exif": {piexif.ExifIFD.DateTimeDigitized: time_string}})
         image.save(file_path, exif=piexif.dump(exif))
+
+    return file_path
+
+
+@pytest.fixture
+def temp_image(tmp_path: Path) -> Path:
+    image_path = create_image(
+        tmp_path, "image.jpg", creation_date=datetime(2020, 1, 1, 12, 00)
+    )
+    yield image_path
 
 
 @pytest.fixture

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,10 +1,39 @@
 from pathlib import Path
+from typing import Dict, Optional
 
 from imgtrf import meta
+from unittest.mock import patch
+import pytest
+from datetime import datetime
 
 
-def test_get_image_meta(temp_directory: Path):
-    file = temp_directory / "source" / "file01.jpg"
-    metadata = meta.get_image_meta(file)
+def test_get_image_meta(temp_image: Path):
+    metadata = meta.get_image_meta(temp_image)
     assert len(metadata) != 0
     assert "DateTime" in metadata.keys()
+
+
+@pytest.mark.parametrize(
+    "mock_meta,expected",
+    [
+        (
+            {
+                "not_a_date": "12345",
+                "not_a_date_2": "abcdef",
+            },
+            None,
+        ),
+        (
+            {
+                "DateTime": "2023:01:01 12:00:00",
+                "not_a_date_2": "abcdef",
+            },
+            datetime(2023, 1, 1, 12, 0, 0),
+        ),
+    ],
+)
+def test_get_image_creation_time(mock_meta: Dict, expected: Optional[datetime]):
+    with patch("imgtrf.meta.get_image_meta", return_value=mock_meta):
+        creation_time = meta.get_image_creation_time('path/should/not/matter')
+
+    assert creation_time == expected


### PR DESCRIPTION
- Added case to tests.
- Added conditional returning None if DateTime does not exist.

## Fixes
#19 