### PR TITLE
Feature/create format flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,45 +3,62 @@
 Basic package to transfer images and videos into a date structure.
 
 This package looks through both images and videos for creation time metadata.
-If found it can copy or move the files from a source directory to a destination directory
-where it will create a new folder structure following below format.
-> **YYYY / MM / DD**  
->  
-> **YYYY**: Year as in '2023'  
-> **MM**: Month as in '01' for January  
-> **DD**: Day as in '02' for second day in the month  
+If found it can copy or move the files from a source directory to a destination directory.
+The sub directory of the destination directory will be based on creation time. As default
+year/month/day e.g 2023/01/27.
 
-# Usage
+## Usage
 
 Copy from one directory to another
-```
+
+```pwsh
 imgtrf copy {source/directory} {destination/directory}
 ```
 
 Move from one directory to another
-```
+
+```pwsh
 imgtrf move {source/directory} {destination/directory}
 ```
 
-Change 'depth' of destination folder structure
+Change format of destination directory structure.  
+Defaults to `Y/m/d` for Year/Month/Day. Directories are seperated by `/` and the format codes can be found [here](./docs/format_codes.md).
+
+```pwsh
+imgtrf copy --dir-format {dir_format} {source/directory} {destination/directory}
 ```
-imgtrf copy --date-level=month {source/directory} {destination/directory}
+
+You can always find specific help with the `--help` flag.
+
+```pwsh
+# Either for the application
+imgtrf --help
+
+# Or for a specific command
+imgtrf copy --help
 ```
 
+## Installation
 
-# Installation
+Installation of image-transfer is simply done via a pip command.
 
-Installation is done via PyPI
-```sh
+```pwsh
 pip install image-transfer
 ```
 
-To support gathering metadata from videos you need to have **FFmpeg** installed and added to your PATH environment variable. FFmpeg can either be installed from their site [ffmpeg.org](https://ffmpeg.org/download.html) or via winget
-```
+### FFmpeg
+
+To support gathering metadata from video files, you need to have **FFmpeg** installed and added to your PATH environment variable. FFmpeg can either be installed from their site [ffmpeg.org](https://ffmpeg.org/download.html)  
+It can also be donwloaded via winget in windows or apt in linux.
+
+```pwsh
 winget install --id Gyan.FFmpeg
 ```
+
 or if on linux
-```sh
+
+```bash
 sudo apt install ffmpeg
 ```
-Make sure to check your environment variables. Some times even a restart of your computer is necessary for them to be read in properly. 
+
+Make sure to check your environment variables. Some times even a restart of your computer is necessary for them to be read in properly.

--- a/docs/format_codes.md
+++ b/docs/format_codes.md
@@ -1,0 +1,32 @@
+Format codes according to 1989 C standard.
+
+|Directive|Meaning|Example|
+|---|---|---|
+|%a|Weekday as locale’s abbreviated name.|Sun, Mon, …, Sat (en_US);<br>So, Mo, …, Sa (de_DE)|
+|%A|Weekday as locale’s full name.|Sunday, Monday, …, Saturday (en_US);<br>Sonntag, Montag, …, Samstag (de_DE)|
+|%w|Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.|0, 1, …, 6|
+|%d|Day of the month as a zero-padded decimal number.|01, 02, …, 31|
+|%b|Month as locale’s abbreviated name.|Jan, Feb, …, Dec (en_US);<br>Jan, Feb, …, Dez (de_DE)|
+|%B|Month as locale’s full name.|January, February, …, December (en_US);<br>Januar, Februar, …, Dezember (de_DE)
+|%m|Month as a zero-padded decimal number.|01, 02, …, 12|
+|%y|Year without century as a zero-padded decimal number.|00, 01, …, 99|
+|%Y|Year with century as a decimal number.|0001, 0002, …, 2013, 2014, …, 9998, 9999|
+|%H|Hour (24-hour clock) as a zero-padded decimal number.|00, 01, …, 23|
+|%I|Hour (12-hour clock) as a zero-padded decimal number.|01, 02, …, 12|
+|%p|Locale’s equivalent of either AM or PM.|AM, PM (en_US);<br>am, pm (de_DE)|	
+|%M|Minute as a zero-padded decimal number.|00, 01, …, 59|
+|%S|Second as a zero-padded decimal number.|00, 01, …, 59|
+|%f|Microsecond as a decimal number, zero-padded to 6 digits.|000000, 000001, …, 999999|
+|%z|UTC offset in the form ±HHMM[SS[.ffffff]] (empty string if the object is naive).|(empty), +0000, -0400, +1030, +063415, -030712.345216|
+|%Z|Time zone name (empty string if the object is naive).|(empty), UTC, GMT|
+|%j|Day of the year as a zero-padded decimal number.|001, 002, …, 366|
+|%U|Week number of the year (Sunday as the first day of the week) as a zero-padded decimal number. All days in a new year preceding the first Sunday are considered to be in week 0.|00, 01, …, 53|
+|%W|Week number of the year (Monday as the first day of the week) as a zero-padded decimal number. All days in a new year preceding the first Monday are considered to be in week 0.|00, 01, …, 53|
+|%c|Locale’s appropriate date and time representation.|Tue Aug 16 21:30:00 1988 (en_US);<br>Di 16 Aug 21:30:00 1988 (de_DE)|
+|%x|Locale’s appropriate date representation.|08/16/88 (None);<br>08/16/1988 (en_US);<br>16.08.1988 (de_DE)|
+|%X|Locale’s appropriate time representation.|21:30:00 (en_US);<br>21:30:00 (de_DE)|
+|%%|A literal '%' character.|%|
+|%G|ISO 8601 year with century representing the year that contains the greater part of the ISO week (%V).|0001, 0002, …, 2013, 2014, …, 9998, 9999|
+|%u|ISO 8601 weekday as a decimal number where 1 is Monday.|1, 2, …, 7|
+|%V|ISO 8601 week as a decimal number with Monday as the first day of the week. Week 01 is the week containing Jan 4.|01, 02, …, 53|
+*Reference: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes*

--- a/docs/format_codes.md
+++ b/docs/format_codes.md
@@ -1,3 +1,5 @@
+# Format Codes
+
 Format codes according to 1989 C standard.
 
 |Directive|Meaning|Example|
@@ -13,7 +15,7 @@ Format codes according to 1989 C standard.
 |%Y|Year with century as a decimal number.|0001, 0002, …, 2013, 2014, …, 9998, 9999|
 |%H|Hour (24-hour clock) as a zero-padded decimal number.|00, 01, …, 23|
 |%I|Hour (12-hour clock) as a zero-padded decimal number.|01, 02, …, 12|
-|%p|Locale’s equivalent of either AM or PM.|AM, PM (en_US);<br>am, pm (de_DE)|	
+|%p|Locale’s equivalent of either AM or PM.|AM, PM (en_US);<br>am, pm (de_DE)| 
 |%M|Minute as a zero-padded decimal number.|00, 01, …, 59|
 |%S|Second as a zero-padded decimal number.|00, 01, …, 59|
 |%f|Microsecond as a decimal number, zero-padded to 6 digits.|000000, 000001, …, 999999|
@@ -29,4 +31,4 @@ Format codes according to 1989 C standard.
 |%G|ISO 8601 year with century representing the year that contains the greater part of the ISO week (%V).|0001, 0002, …, 2013, 2014, …, 9998, 9999|
 |%u|ISO 8601 weekday as a decimal number where 1 is Monday.|1, 2, …, 7|
 |%V|ISO 8601 week as a decimal number with Monday as the first day of the week. Week 01 is the week containing Jan 4.|01, 02, …, 53|
-*Reference: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes*
+> *Reference: <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes>*

--- a/src/imgtrf/cli.py
+++ b/src/imgtrf/cli.py
@@ -9,6 +9,12 @@ from imgtrf.core import copy_files, move_files
 app = typer.Typer(name="Image Transfer", add_completion=False)
 
 
+_option_dir_format = typer.Option(
+    default="Y/m/d",
+    help="""Format of destination directory.Directories seperated with '/' and format codes with '%' followed by single character.""",
+)
+
+
 @app.callback()
 def main(verbose: bool = False, debug: bool = False):
     """Image Transfer
@@ -42,7 +48,7 @@ def copy(
 def move(
     src_dir: str,
     dest_dir: str,
-    dir_format: str = "Y/m/d",
+    dir_format: str = _option_dir_format,
 ):
     """Move files from source dir to destination dir"""
 

--- a/src/imgtrf/cli.py
+++ b/src/imgtrf/cli.py
@@ -4,7 +4,7 @@ import typer
 from rich import print
 
 from imgtrf import logger
-from imgtrf.core import copy_files, move_files, DateDepth
+from imgtrf.core import copy_files, move_files
 
 app = typer.Typer(name="Image Transfer", add_completion=False)
 
@@ -24,11 +24,9 @@ def main(verbose: bool = False, debug: bool = False):
 def copy(
     src_dir: str,
     dest_dir: str,
-    date_level: str = "day",
+    dir_format: str = "Y/m/d",
 ):
     """Copy files from source dir to destination dir"""
-
-    date_depth = _parse_date_depth(date_level)
 
     source_path = Path(src_dir).resolve()
     destination_path = Path(dest_dir).resolve()
@@ -37,18 +35,16 @@ def copy(
         print("Source directory does not exists")
         raise NotADirectoryError(src_dir)
 
-    copy_files(src_dir=source_path, dest_dir=destination_path, date_depth=date_depth)
+    copy_files(src_dir=source_path, dest_dir=destination_path, dir_format=dir_format)
 
 
 @app.command()
 def move(
     src_dir: str,
     dest_dir: str,
-    date_level: str = "day",
+    dir_format: str = "Y/m/d",
 ):
     """Move files from source dir to destination dir"""
-
-    date_depth = _parse_date_depth(date_level)
 
     source_path = Path(src_dir).resolve()
     destination_path = Path(dest_dir).resolve()
@@ -57,26 +53,4 @@ def move(
         print("Source directory does not exists")
         raise NotADirectoryError(src_dir)
 
-    move_files(src_dir=source_path, dest_dir=destination_path, date_depth=date_depth)
-
-
-def _parse_date_depth(date_depth: str) -> DateDepth:
-    """Parses string to DateDepth
-
-    Args:
-        date_depth (str): Depth as 'day' | 'month' | 'year'
-
-    Raises:
-        ValueError: If not argument matches
-
-    Returns:
-        DateDepth: Date depth as enum
-    """
-    if date_depth.lower() == "day":
-        return DateDepth.DAY
-    if date_depth.lower() == "month":
-        return DateDepth.MONTH
-    if date_depth.lower() == "year":
-        return DateDepth.YEAR
-
-    raise ValueError(f"Argument {date_depth=} not recognised")
+    move_files(src_dir=source_path, dest_dir=destination_path, dir_format=dir_format)

--- a/src/imgtrf/core.py
+++ b/src/imgtrf/core.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from enum import Enum, auto
 from pathlib import Path
 from typing import Iterator, List, Tuple
 import shutil
@@ -13,6 +12,58 @@ from imgtrf import meta
 log = logging.getLogger(__name__)
 
 
+def copy_files(
+    src_dir: Path,
+    dest_dir: Path,
+    dir_format: str,
+    skip_existing=True,
+) -> None:
+    """Copies files from source to target directory"""
+    src_dest_paths = _create_src_dest_pairs(
+        src_dir=src_dir,
+        dest_dir=dest_dir,
+        dir_format=dir_format,
+        skip_existing=skip_existing,
+    )
+
+    if not src_dest_paths:
+        log.info("No files to copy")
+        return
+
+    with Progress(console=console) as progress:
+        for src_file_path, target_path in progress.track(
+            src_dest_paths, description="Copying"
+        ):
+            log.info(f"Copying {src_file_path} to {target_path}")
+            _copy_file(src_file_path, target_path)
+
+
+def move_files(
+    src_dir: Path,
+    dest_dir: Path,
+    dir_format: str,
+    skip_existing=True,
+) -> None:
+    """Copies files from source to target directory"""
+    src_dest_paths = _create_src_dest_pairs(
+        src_dir=src_dir,
+        dest_dir=dest_dir,
+        dir_format=dir_format,
+        skip_existing=skip_existing,
+    )
+
+    if not src_dest_paths:
+        log.info("No files to move")
+        return
+
+    with Progress(console=console) as progress:
+        for src_file_path, target_path in progress.track(
+            src_dest_paths, description="Moving"
+        ):
+            log.info(f"Moving {src_file_path} to {target_path}")
+            _move_file(src_file_path, target_path)
+
+
 def walk(root: str) -> Iterator[Path]:
     """Recureivly iterates through directories and yields file paths"""
     for path in Path(root).iterdir():
@@ -22,33 +73,35 @@ def walk(root: str) -> Iterator[Path]:
         yield path
 
 
-class DateDepth(Enum):
-    YEAR = auto()
-    MONTH = auto()
-    DAY = auto()
+def _create_src_dest_pairs(
+    src_dir: Path, dest_dir: Path, dir_format: str, skip_existing: bool = True
+) -> List[Tuple[str, str]]:
+    src_dest_paths: List[Tuple[str, str]] = []
+
+    with Progress(console=console) as progress:
+        for src_file_path in progress.track(
+            walk(src_dir),
+            description="Indexing",
+        ):
+            target_path = _create_path_by_creation_date(
+                src_file_path=src_file_path, dest_dir=dest_dir, dir_format=dir_format
+            )
+            if skip_existing and target_path.exists():
+                log.info(f"Skipping {src_file_path}")
+                continue
+            else:
+                src_dest_paths.append((src_file_path, target_path))
+        return src_dest_paths
 
 
 def _create_path_by_creation_date(
-    src_file_path: Path, dest_dir: Path, date_depth: DateDepth
+    src_file_path: Path, dest_dir: Path, dir_format: str
 ) -> Path:
     """Returns path based on creation date of file"""
     date = meta.get_creation_time(src_file_path)
+    sub_directories = _create_path_from(date, dir_format)
 
-    if date_depth == DateDepth.YEAR:
-        return dest_dir.joinpath(str(date.year), src_file_path.name)
-
-    if date_depth == DateDepth.MONTH:
-        return dest_dir.joinpath(
-            str(date.year), f"{date.month:02d}", src_file_path.name
-        )
-
-    if date_depth == DateDepth.DAY:
-        return dest_dir.joinpath(
-            str(date.year),
-            f"{date.month:02d}",
-            f"{date.day:02d}",
-            src_file_path.name,
-        )
+    return dest_dir / sub_directories / src_file_path.name
 
 
 def _create_path_from(date_time: datetime, dir_format: str) -> Path:
@@ -68,9 +121,9 @@ def _create_path_from(date_time: datetime, dir_format: str) -> Path:
     # Assume that we strictly indicate format codes with %
     if "%" in dir_format:
         return Path(date_time.strftime(dir_format))
-    
-    # If no % signs in dir_format, assume that it is loosly formated and that evry 
-    # character could be a format code. 
+
+    # If no % signs in dir_format, assume that it is loosly formated and that evry
+    # character could be a format code.
     path = Path()
     for directory_string in dir_format.split("/"):
         folder_name = ""
@@ -86,73 +139,6 @@ def _create_path_from(date_time: datetime, dir_format: str) -> Path:
 
     path
     return path
-
-
-def copy_files(
-    src_dir: Path,
-    dest_dir: Path,
-    date_depth: DateDepth = DateDepth.DAY,
-    skip_existing=True,
-) -> None:
-    """Copies files from source to target directory"""
-    src_dest_paths = _create_src_dest_pairs(
-        src_dir, dest_dir, date_depth, skip_existing
-    )
-
-    if not src_dest_paths:
-        log.info("No files to copy")
-        return
-
-    with Progress(console=console) as progress:
-        for src_file_path, target_path in progress.track(
-            src_dest_paths, description="Copying"
-        ):
-            log.info(f"Copying {src_file_path} to {target_path}")
-            _copy_file(src_file_path, target_path)
-
-
-def move_files(
-    src_dir: Path,
-    dest_dir: Path,
-    date_depth: DateDepth = DateDepth.DAY,
-    skip_existing=True,
-) -> None:
-    """Copies files from source to target directory"""
-    src_dest_paths = _create_src_dest_pairs(
-        src_dir, dest_dir, date_depth, skip_existing
-    )
-
-    if not src_dest_paths:
-        log.info("No files to move")
-        return
-
-    with Progress(console=console) as progress:
-        for src_file_path, target_path in progress.track(
-            src_dest_paths, description="Moving"
-        ):
-            log.info(f"Moving {src_file_path} to {target_path}")
-            _move_file(src_file_path, target_path)
-
-
-def _create_src_dest_pairs(
-    src_dir: Path, dest_dir: Path, date_depth: DateDepth, skip_existing: bool = True
-) -> List[Tuple[str, str]]:
-    src_dest_paths: List[Tuple[str, str]] = []
-
-    with Progress(console=console) as progress:
-        for src_file_path in progress.track(
-            walk(src_dir),
-            description="Indexing",
-        ):
-            target_path = _create_path_by_creation_date(
-                src_file_path, dest_dir, date_depth=date_depth
-            )
-            if skip_existing and target_path.exists():
-                log.info(f"Skipping {src_file_path}")
-                continue
-            else:
-                src_dest_paths.append((src_file_path, target_path))
-        return src_dest_paths
 
 
 def _copy_file(src_file_path: Path, dest_path: Path) -> None:

--- a/src/imgtrf/core.py
+++ b/src/imgtrf/core.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+import string
 from typing import Iterator, List, Tuple
 import shutil
 
@@ -122,12 +123,15 @@ def _create_path_from(date_time: datetime, dir_format: str) -> Path:
     if "%" in dir_format:
         return Path(date_time.strftime(dir_format))
 
-    # If no % signs in dir_format, assume that it is loosly formated and that evry
+    # If no % signs in dir_format, assume that it is loosly formated and that every
     # character could be a format code.
     path = Path()
     for directory_string in dir_format.split("/"):
         folder_name = ""
         for char in directory_string:
+            if char not in string.ascii_letters:
+                folder_name += char
+                continue
             try:
                 dir_part = date_time.strftime(f"%{char}")
             except ValueError:
@@ -137,7 +141,6 @@ def _create_path_from(date_time: datetime, dir_format: str) -> Path:
                 folder_name += dir_part
         path = path.joinpath(folder_name)
 
-    path
     return path
 
 

--- a/src/imgtrf/core.py
+++ b/src/imgtrf/core.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum, auto
 from pathlib import Path
 from typing import Iterator, List, Tuple
@@ -48,6 +49,43 @@ def _create_path_by_creation_date(
             f"{date.day:02d}",
             src_file_path.name,
         )
+
+
+def _create_path_from(date_time: datetime, dir_format: str) -> Path:
+    """Creates formated path from date_time
+
+    Reference:
+        https://docs.python.org/3.8/library/datetime.html#strftime-and-strptime-format-codes
+
+    Args:
+        date_time (datetime): time to be used in path formatting
+        dir_format (str): String including format codes of how to format the path
+
+    Returns:
+        Path: A path formatted by datetime
+    """
+
+    # Assume that we strictly indicate format codes with %
+    if "%" in dir_format:
+        return Path(date_time.strftime(dir_format))
+    
+    # If no % signs in dir_format, assume that it is loosly formated and that evry 
+    # character could be a format code. 
+    path = Path()
+    for directory_string in dir_format.split("/"):
+        folder_name = ""
+        for char in directory_string:
+            try:
+                dir_part = date_time.strftime(f"%{char}")
+            except ValueError:
+                # If we cant translate, we append that character instead.
+                folder_name += char
+            else:
+                folder_name += dir_part
+        path = path.joinpath(folder_name)
+
+    path
+    return path
 
 
 def copy_files(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from typer.testing import CliRunner
 from imgtrf.cli import app
 
@@ -16,6 +18,16 @@ def test_copy(temp_directory: Path):
     ).exists()
 
 
+def test_copy_format(temp_directory: Path):
+    src_path = temp_directory / "source"
+    dest_path = temp_directory / "destination"
+    result = runner.invoke(
+        app, ["copy", "--dir-format", "Y/m", str(src_path), str(dest_path)]
+    )
+    assert result.exit_code == 0
+    assert (temp_directory / "destination" / "2020" / "01" / "file01.jpg").exists()
+
+
 def test_copy_not_a_directory(temp_directory: Path):
     src_path = temp_directory / "not-exists"
     dest_path = temp_directory / "destination"
@@ -23,3 +35,25 @@ def test_copy_not_a_directory(temp_directory: Path):
     result = runner.invoke(app, ["copy", str(src_path), str(dest_path)])
 
     assert result.exit_code == 1
+
+
+def test_move(temp_directory: Path):
+    src_path = temp_directory / "source"
+    dest_path = temp_directory / "destination"
+    result = runner.invoke(app, ["move", str(src_path), str(dest_path)])
+    assert result.exit_code == 0
+    assert (
+        temp_directory / "destination" / "2020" / "01" / "01" / "file01.jpg"
+    ).exists()
+    assert not (temp_directory / "source" / "file01.jpg").exists()
+
+
+def test_move_format(temp_directory: Path):
+    src_path = temp_directory / "source"
+    dest_path = temp_directory / "destination"
+    result = runner.invoke(
+        app, ["move", "--dir-format", "Y/m", str(src_path), str(dest_path)]
+    )
+    assert result.exit_code == 0
+    assert (temp_directory / "destination" / "2020" / "01" / "file01.jpg").exists()
+    assert not (temp_directory / "source" / "file01.jpg").exists()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,10 +7,10 @@ from imgtrf import core
 
 
 def test_copy_files(temp_directory: Path):
-    src_path = temp_directory / "source"
-    dest_path = temp_directory / "destination"
+    src_dir = temp_directory / "source"
+    dest_dir = temp_directory / "destination"
 
-    core.copy_files(src_path, dest_path)
+    core.copy_files(src_dir=src_dir, dest_dir=dest_dir, dir_format="%Y/%m/%d")
 
     assert (
         temp_directory / "destination" / "2020" / "01" / "01" / "file01.jpg"
@@ -21,10 +21,10 @@ def test_copy_files(temp_directory: Path):
 
 
 def test_move_files(temp_directory: Path):
-    src_path = temp_directory / "source"
-    dest_path = temp_directory / "destination"
+    src_dir = temp_directory / "source"
+    dest_dir = temp_directory / "destination"
 
-    core.move_files(src_path, dest_path)
+    core.move_files(src_dir=src_dir, dest_dir=dest_dir, dir_format="%Y/%m/%d")
 
     assert (
         temp_directory / "destination" / "2020" / "01" / "01" / "file01.jpg"
@@ -32,8 +32,6 @@ def test_move_files(temp_directory: Path):
 
     assert not (temp_directory / "source" / "file01.jpg").exists()
     assert not (temp_directory / "source" / "subfolder" / "file02.jpg").exists()
-
-
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,25 @@ def test_copy_files(temp_directory: Path):
         temp_directory / "destination" / "2020" / "01" / "01" / "file01.jpg"
     ).exists()
 
+    assert (temp_directory / "source" / "file01.jpg").exists()
+    assert (temp_directory / "source" / "subfolder" / "file02.jpg").exists()
+
+
+def test_move_files(temp_directory: Path):
+    src_path = temp_directory / "source"
+    dest_path = temp_directory / "destination"
+
+    core.move_files(src_path, dest_path)
+
+    assert (
+        temp_directory / "destination" / "2020" / "01" / "01" / "file01.jpg"
+    ).exists()
+
+    assert not (temp_directory / "source" / "file01.jpg").exists()
+    assert not (temp_directory / "source" / "subfolder" / "file02.jpg").exists()
+
+
+
 
 @pytest.mark.parametrize(
     "dir_format,expected_path",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from datetime import datetime
+
+import pytest
 
 from imgtrf import core
 
@@ -12,3 +15,21 @@ def test_copy_files(temp_directory: Path):
     assert (
         temp_directory / "destination" / "2020" / "01" / "01" / "file01.jpg"
     ).exists()
+
+
+@pytest.mark.parametrize(
+    "dir_format,expected_path",
+    [
+        ("%Y/%m/%d", Path("2023/01/01")),
+        ("Y/m/d", Path("2023/01/01")),
+        ("Year-%Y/Month-%m/Day-%d", Path("Year-2023/Month-01/Day-01")),
+        ("%Y/%Y-%m-%d", Path("2023/2023-01-01")),
+        ("Y/Y-m-d", Path("2023/2023-01-01")),
+        ("%A %B %Y", Path("Sunday January 2023")),
+        ("A B Y", Path("Sunday January 2023")),
+    ],
+)
+def test_create_path_from(dir_format: str, expected_path: Path):
+    dt = datetime(2023, 1, 1, 12, 0)
+    output = core._create_path_from(dt, dir_format)
+    assert output == expected_path


### PR DESCRIPTION
# Creation of directory format flag
Creation of `--dir-format` flag for handling directory format structure.
This replaces `--date-level` which is now completely removed.

## Fixes
#5 