### PR TITLE
Remove 'all' extras from typer.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
+    "typer",
+    "rich",
     "Pillow",
     "ffmpeg-python",
-    "typer[all]",
-    "rich"
 ]
 
 [project.urls]


### PR DESCRIPTION
# Remove 'all' extras from `typer`.

- This will remove `shellingham.`
- `rich` is kept as an direct dependency.

Closes #22 